### PR TITLE
Add support to convert to avif format, using the pillow-avif-plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ sudo pacman -S ffmpeg
 ```
 
 ###
-GNOME's file viewer [Nautilus](https://apps.gnome.org/en-GB/app/org.gnome.Nautilus/) should be installed, otehrwise it will be hard to install extension to it.
+GNOME's file viewer [Nautilus](https://apps.gnome.org/en-GB/app/org.gnome.Nautilus/) should be installed, otherwise it will be hard to install extension to it.
 
 ## 2.2 Optional dependencies
 ### pyheif (HEIC, AVIF)
@@ -111,6 +111,10 @@ pip install pyheif
 You may need to install some dependencies before installing pyheif. Otherwise you could get an error installing it.
 ```bash
 yum install libffi libheif-devel libde265-devel
+```
+In addition, to convert *to* **avif** format you will need this [plugin for Pillow](https://pypi.org/project/pillow-avif-plugin/).
+```bash
+pip install pillow-avif-plugin
 ```
 
 ### jxlpy (JXL)
@@ -206,7 +210,16 @@ Without jxlpy, the converter won't be able to convert from- or to jxl file forma
 To solve this warning, you need to install jxlpy using pip.
 <br/>View the [Optional dependencies](#22-optional-dependencies) section to get installation instructions.
 
-### (002): No permission to self-update
+### (002): "pillow-avif-plugin" not found
+<b>Causes:</b><br/>
+This warning is caused, because the script is not able to find your pillow-avif-plugin installation.
+<br/><br/><b>Possible Effects:</b><br/>
+Without pillow-avif-plugin, the converter won't be able to convert to avif file format.
+<br/><br/><b>How to solve?</b><br/>
+To solve this warning, you need to install pillow-avif-plugin using pip.
+<br/>View the [Optional dependencies](#22-optional-dependencies) section to get installation instructions.
+
+### (003): No permission to self-update
 <b>Causes:</b><br/>
 The program has no permission to write it's own file.
 <br/>This warning usually occurs when the script is located at "/usr/share/nautilus-python/extensions/".
@@ -218,7 +231,7 @@ To remove the release popup, you may disable the corresponding setting. To do th
 <br/>To get self updates, the script needs the permissions to write to itself. This can be done by changing the file permissions using [chmod](https://www.man7.org/linux/man-pages/man1/chmod.1.html) or by running the script as a privileged user.
 <br/>To be able to self-update, the user, who is executing the script (by starting nautilus) needs permissions to edit the script itself.
 
-### (003): No permission to write configuration file
+### (004): No permission to write configuration file
 <b>Causes:</b><br/>
 The program has no permission to write in the dictionary where it is installed.
 <br/>This warning usually occurs when the script is located at "/usr/share/nautilus-python/extensions/".
@@ -231,7 +244,7 @@ To fix this, the script needs the permissions to write inside the folder, where 
 <br/>To use the configuration file, the user, who is executing the script (by starting nautilus) needs permissions create and edit files inside the installation dictionary.
 <br/><br/>To prevent the settings from being reset, you can add a config file to the dictionary. Note that the file will not be update if new configurations are added.
 
-### (004): Double script installation detected
+### (005): Double script installation detected
 <b>Causes:</b><br/>
 The script is installed in a home location and finds another script with the same name in the root installation folder ("/usr/share/nautilus-python/extensions/").
 <br/><br/><b>Possible Effects:</b><br/>
@@ -239,7 +252,7 @@ The context menu may appear two times.
 <br/><br/><b>How to solve?</b><br/>
 To solve this issue, you have to remove one of the files (in "/usr/share/nautilus-python/extensions/" or in "~/.local/share/nautilus-python/extensions/")
 
-### (005): Attempting to update
+### (006): Attempting to update
 <b>Causes:</b><br/>
 Automatic updates are enabled and there are updates available.
 This is not an error, just information to make problems easier to solve.

--- a/nautilus-fileconverter.py
+++ b/nautilus-fileconverter.py
@@ -19,6 +19,7 @@ scriptUpdateable = os.access(f"{currentPath}/{os.path.basename(__file__)}", os.W
 # --- Check if dependencies are installed and imported ---
 pyheifInstalled = False
 jxlpyInstalled = False
+pillow_avif_pluginInstalled = False
 
 try:
     import pyheif
@@ -35,11 +36,17 @@ except ImportError:
     jxlpyInstalled = False
     print(f"WARNING(Nautilus-file-converter)(001): \"jxlpy\" not found, if you want to convert from- or to jxl format. View https://github.com/Lich-Corals/Nautilus-fileconverter-43/blob/main/README.md#6-warnings-and-errors for more information.")
 
+try:
+    import pillow_avif
+    pillow_avif_pluginInstalled = True
+except ImportError:
+        print(f"WARNING(Nautilus-file-converter)(002) \"pillow-avif-plugin\" not found, if you want to convert to avif format. View https://github.com/Lich-Corals/Nautilus-fileconverter-43/blob/main/README.md#6-warnings-and-errors for more information.")
+
 if not scriptUpdateable:
-    print(f"WARNING(Nautilus-file-converter)(002): No permission to self-update; script at \"{currentPath}/{os.path.basename(__file__)}\" is not writeable. View https://github.com/Lich-Corals/Nautilus-fileconverter-43/blob/main/README.md#6-warnings-and-errors for more information.")
+    print(f"WARNING(Nautilus-file-converter)(003): No permission to self-update; script at \"{currentPath}/{os.path.basename(__file__)}\" is not writeable. View https://github.com/Lich-Corals/Nautilus-fileconverter-43/blob/main/README.md#6-warnings-and-errors for more information.")
 
 if not os.access(currentPath, os.W_OK):
-    print(f"WARNING(Nautilus-file-converter)(003): No permission to write configuration file; \"{currentPath}\" is not writeable. View https://github.com/Lich-Corals/Nautilus-fileconverter-43/blob/main/README.md#6-warnings-and-errors for more information.")
+    print(f"WARNING(Nautilus-file-converter)(004): No permission to write configuration file; \"{currentPath}\" is not writeable. View https://github.com/Lich-Corals/Nautilus-fileconverter-43/blob/main/README.md#6-warnings-and-errors for more information.")
 
 # --- Set default configs ---
 _configPreset = {                                 # These are the pre-defined default settings; edit NFC43-Config.json if the program is installed in your home dictionary.
@@ -76,7 +83,7 @@ if _config["automaticUpdates"]:
             "https://raw.githubusercontent.com/Lich-Corals/Nautilus-fileconverter-43/main/nautilus-fileconverter.py") as f:
         onlineFile = f.read().decode().strip()
     if converterVersion not in onlineFile:
-        print(f"UPDATES(Nautilus-file-converter)(005): Current Version: {converterVersion}\n"
+        print(f"UPDATES(Nautilus-file-converter)(006): Current Version: {converterVersion}\n"
               f"                                       Attempting to update...")
         if scriptUpdateable:
             print("Updating...")
@@ -88,7 +95,7 @@ if _config["automaticUpdates"]:
 
 # --- Check for duplicate script if enabled ---
 if _config["checkForDoubleInstallation"] and scriptUpdateable and os.path.isfile("/usr/share/nautilus-python/extensions/nautilus-fileconverter.py"):
-    print(f"WARNING(Nautilus-file-converter)(004): Double script installation detected. View https://github.com/Lich-Corals/Nautilus-fileconverter-43/blob/main/README.md#6-warnings-and-errors for more information.")
+    print(f"WARNING(Nautilus-file-converter)(005): Double script installation detected. View https://github.com/Lich-Corals/Nautilus-fileconverter-43/blob/main/README.md#6-warnings-and-errors for more information.")
 
 # --- Disable debug printing ---
 # comment it out (using '#' in front of the line) if you wish debug printing
@@ -160,6 +167,8 @@ class FileConverterMenuProvider(GObject.GObject, Nautilus.MenuProvider):
 
     jxlpyWriteFormats = [{'name': 'JXL'}]
 
+    pillow_avif_pluginWriteFormats = [{ 'name': 'AVIF'}]
+
     WRITE_FORMATS_SQUARE = [{'name': 'PNG: 16x16', 'extension': 'png', 'square': '16'},
                             {'name': 'PNG: 32x32', 'extension': 'png', 'square': '32'},
                             {'name': 'PNG: 64x64', 'extension': 'png', 'square': '64'},
@@ -213,6 +222,9 @@ class FileConverterMenuProvider(GObject.GObject, Nautilus.MenuProvider):
     if jxlpyInstalled:
         READ_FORMATS_IMAGE = READ_FORMATS_IMAGE + (jxlpyReadFormats,)
         WRITE_FORMATS_IMAGE.extend(jxlpyWriteFormats)
+
+    if pillow_avif_pluginInstalled:
+        WRITE_FORMATS_IMAGE.extend(pillow_avif_pluginWriteFormats)
 
 # --- Get file mime and trigger submenu building ---
     def get_file_items(self, *args) -> List[Nautilus.MenuItem]:


### PR DESCRIPTION
This pull request introduces the use of the `pillow-avif-plugin` to add support to write files in **avif** format.

The README file has also been updated to reflect this change, including the installation instructions, as well as shifting the error codes up by one. This last change was made for consistency with the document to group related errors (missing optional dependencies) together.